### PR TITLE
Use @juliangruber’s isarray module to add support for older browsers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var isArray = require('isarray')
+
 /**
  * Convert an array-like object into an `Array`.
  * If `collection` is already an `Array`, then will return a clone of `collection`.
@@ -14,7 +16,7 @@ module.exports = function toArray(collection, options) {
   if (typeof collection === 'undefined') return []
   if (collection === null) return [null]
   if (typeof window != 'undefined' && collection === window) return [window]
-  if (Array.isArray(collection)) return collection.slice()
+  if (isArray(collection)) return collection.slice()
   if (typeof collection.length != 'number') return [collection]
   if (typeof collection === 'function') return [collection]
   if (collection.length === 0) return []

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "Convert array like items or individual items into arrays",
   "keywords": [],
-  "dependencies": {},
+  "dependencies": {
+    "isarray": "0.0.1"
+  },
   "devDependencies": {
     "mocha": "*"
   },


### PR DESCRIPTION
Hey there,
I’m using this module in [object-reduce](https://github.com/michaelrhodes/object-reduce) and I’m pretty sure lack of Array.isArray is the only thing stopping Testling from showing a little green tick next to IE6. So anyway, I’d love to have this patch merged. :)
